### PR TITLE
chore(deps): override lodash to fix security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "overrides": {
             "tar": ">=7.5.3",
             "hono": ">=4.11.4",
-            "esbuild": ">=0.25.0"
+            "esbuild": ">=0.25.0",
+            "lodash": ">=4.17.23"
         },
         "onlyBuiltDependencies": [
             "better-sqlite3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   tar: '>=7.5.3'
   hono: '>=4.11.4'
   esbuild: '>=0.25.0'
+  lodash: '>=4.17.23'
 
 importers:
 
@@ -3064,8 +3065,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   long@5.2.3:
     resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
@@ -4501,13 +4502,13 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 10.5.0
       '@chevrotain/types': 10.5.0
-      lodash: 4.17.21
+      lodash: 4.17.23
     optional: true
 
   '@chevrotain/gast@10.5.0':
     dependencies:
       '@chevrotain/types': 10.5.0
-      lodash: 4.17.21
+      lodash: 4.17.23
     optional: true
 
   '@chevrotain/types@10.5.0':
@@ -6663,7 +6664,7 @@ snapshots:
       '@chevrotain/gast': 10.5.0
       '@chevrotain/types': 10.5.0
       '@chevrotain/utils': 10.5.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       regexp-to-ast: 0.5.0
     optional: true
 
@@ -7940,7 +7941,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.21:
+  lodash@4.17.23:
     optional: true
 
   long@5.2.3: {}
@@ -9326,7 +9327,7 @@ snapshots:
 
   whatwg-url@8.7.0:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.23
       tr46: 2.1.0
       webidl-conversions: 6.1.0
     optional: true


### PR DESCRIPTION
Fixes Lodash has Prototype Pollution Vulnerability in `_.unset` and `_.omit` functions (CVE-2025-13465). Forces lodash to >=4.17.23.