### PR TITLE
chore(deps): override axios to fix security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
             "esbuild": "0.27.2",
             "lodash": "4.17.23",
             "fastify": ">=5.7.2",
-            "@isaacs/brace-expansion": ">=5.0.1"
+            "@isaacs/brace-expansion": ">=5.0.1",
+            "axios": ">=1.13.5"
         },
         "onlyBuiltDependencies": [
             "better-sqlite3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   lodash: 4.17.23
   fastify: '>=5.7.2'
   '@isaacs/brace-expansion': '>=5.0.1'
+  axios: '>=1.13.5'
 
 importers:
 
@@ -1921,8 +1922,8 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
-  axios@1.13.2:
-    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+  axios@1.13.5:
+    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -5472,7 +5473,7 @@ snapshots:
       '@napgram/runtime-kit': 0.1.18(@electric-sql/pglite@0.3.2)(@opentelemetry/api@1.9.0)(@prisma/client@7.2.0(prisma@7.2.0(@types/react@19.2.7)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(better-sqlite3@12.6.2)(mysql2@3.15.3)(pg@8.18.0)(postgres@3.4.7)(prisma@7.2.0(@types/react@19.2.7)(better-sqlite3@12.6.2)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(ws@8.19.0)
       '@napgram/sdk': 0.1.19
       '@sentry/node': 10.32.1
-      axios: 1.13.2
+      axios: 1.13.5
       semver: 7.7.3
       yaml: 2.8.2
       zod: 4.3.5
@@ -6880,7 +6881,7 @@ snapshots:
   aws-ssl-profiles@1.1.2:
     optional: true
 
-  axios@1.13.2:
+  axios@1.13.5:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5


### PR DESCRIPTION
Fixes Axios is Vulnerable to Denial of Service via __proto__ Key in mergeConfig (CVE-2026-25639). Forces axios to >=1.13.5.