### PR TITLE
chore(deps): override @hono/node-server to fix security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
             "axios": ">=1.13.5",
             "ajv": ">=8.18.0",
             "minimatch": ">=10.2.1",
-            "rollup": ">=4.59.0"
+            "rollup": ">=4.59.0",
+            "@hono/node-server": ">=1.19.10"
         },
         "onlyBuiltDependencies": [
             "better-sqlite3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   ajv: '>=8.18.0'
   minimatch: '>=10.2.1'
   rollup: '>=4.59.0'
+  '@hono/node-server': '>=1.19.10'
 
 importers:
 
@@ -758,8 +759,8 @@ packages:
   '@fuman/utils@0.0.19':
     resolution: {integrity: sha512-4qVrZ9AjKYztLJsNr1Tp7kL48b22dvVLN1iVW+Me8ZSQ0ILN0qknoxjsczVPReF7+GDWgknNxR2l6ggrA4SZyw==}
 
-  '@hono/node-server@1.19.6':
-    resolution: {integrity: sha512-Shz/KjlIeAhfiuE93NDKVdZ7HdBVLQAfdbaXEaoAVO3ic9ibRSLGIQGkcBbFyuLr+7/1D5ZCINM8B+6IvXeMtw==}
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: 4.12.5
@@ -4965,7 +4966,7 @@ snapshots:
 
   '@fuman/utils@0.0.19': {}
 
-  '@hono/node-server@1.19.6(hono@4.12.5)':
+  '@hono/node-server@1.19.11(hono@4.12.5)':
     dependencies:
       hono: 4.12.5
     optional: true
@@ -6289,7 +6290,7 @@ snapshots:
       '@electric-sql/pglite': 0.3.2
       '@electric-sql/pglite-socket': 0.0.6(@electric-sql/pglite@0.3.2)
       '@electric-sql/pglite-tools': 0.2.7(@electric-sql/pglite@0.3.2)
-      '@hono/node-server': 1.19.6(hono@4.12.5)
+      '@hono/node-server': 1.19.11(hono@4.12.5)
       '@mrleebo/prisma-ast': 0.12.1
       '@prisma/get-platform': 6.8.2
       '@prisma/query-plan-executor': 6.18.0


### PR DESCRIPTION
Fixes @hono/node-server has authorization bypass for protected static paths via encoded slashes in Serve Static Middleware (CVE-2026-29087). Forces @hono/node-server to >=1.19.10.