### PR TITLE
chore(deps): override vite to fix security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,1 +1,41 @@
-{"name":"napgram-root","version":"0.1.5","private":true,"packageManager":"pnpm@10.33.0","scripts":{},"dependencies":{"@napgram/sdk":"^0.2.0"},"pnpm":{"overrides":{"tar":"^7.5.8","hono":"4.12.10","esbuild":"^0.28.0","lodash":"4.18.1","fastify":">=5.7.2","@isaacs/brace-expansion":">=5.0.1","axios":">=1.13.5","ajv":">=8.18.0","minimatch":">=10.2.1","rollup":">=4.59.0","@hono/node-server":">=1.19.10","flatted":">=3.4.2","effect":">=3.20.0"},"onlyBuiltDependencies":["better-sqlite3","cpu-features","esbuild","protobufjs","sharp","silk-sdk","ssh2"]},"devDependencies":{"typescript":"6.0.2","@types/node":"25.5.2"}}
+{
+    "name": "napgram-root",
+    "version": "0.1.5",
+    "private": true,
+    "packageManager": "pnpm@10.33.0",
+    "scripts": {},
+    "dependencies": {
+        "@napgram/sdk": "^0.2.0"
+    },
+    "pnpm": {
+        "overrides": {
+            "tar": "^7.5.8",
+            "hono": "4.12.10",
+            "esbuild": "^0.28.0",
+            "lodash": "4.18.1",
+            "fastify": ">=5.7.2",
+            "@isaacs/brace-expansion": ">=5.0.1",
+            "axios": ">=1.13.5",
+            "ajv": ">=8.18.0",
+            "minimatch": ">=10.2.1",
+            "rollup": ">=4.59.0",
+            "@hono/node-server": ">=1.19.10",
+            "flatted": ">=3.4.2",
+            "effect": ">=3.20.0",
+            "vite": ">=8.0.5"
+        },
+        "onlyBuiltDependencies": [
+            "better-sqlite3",
+            "cpu-features",
+            "esbuild",
+            "protobufjs",
+            "sharp",
+            "silk-sdk",
+            "ssh2"
+        ]
+    },
+    "devDependencies": {
+        "typescript": "6.0.2",
+        "@types/node": "25.5.2"
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   '@hono/node-server': '>=1.19.10'
   flatted: '>=3.4.2'
   effect: '>=3.20.0'
+  vite: '>=8.0.5'
 
 importers:
 
@@ -1672,7 +1673,7 @@ packages:
     resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=8.0.5'
     peerDependenciesMeta:
       msw:
         optional: true
@@ -3641,7 +3642,7 @@ packages:
       '@vitest/ui': 4.1.2
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=8.0.5'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true


### PR DESCRIPTION
Fixes Vite Vulnerable to Path Traversal in Optimized Deps `.map` Handling (). Forces vite to >=8.0.5.