### PR TITLE
chore(deps): override follow-redirects to fix security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
             "@hono/node-server": ">=1.19.10",
             "flatted": ">=3.4.2",
             "effect": ">=3.20.0",
-            "vite": ">=8.0.5"
+            "vite": ">=8.0.5",
+            "follow-redirects": ">=1.16.0"
         },
         "onlyBuiltDependencies": [
             "better-sqlite3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
   flatted: '>=3.4.2'
   effect: '>=3.20.0'
   vite: '>=8.0.5'
+  follow-redirects: '>=1.16.0'
 
 importers:
 
@@ -2519,8 +2520,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -6709,7 +6710,7 @@ snapshots:
 
   axios@1.14.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -7398,7 +7399,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   form-data@4.0.5:
     dependencies:
@@ -8522,7 +8523,7 @@ snapshots:
   skia-canvas@3.0.8:
     dependencies:
       detect-libc: 2.1.2
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       https-proxy-agent: 7.0.6
       string-split-by: 1.0.0
     transitivePeerDependencies:


### PR DESCRIPTION
Fixes follow-redirects leaks Custom Authentication Headers to Cross-Domain Redirect Targets (). Forces follow-redirects to >=1.16.0.